### PR TITLE
Add Alumni section, move former postdocs, update news

### DIFF
--- a/_data/alumni_members.yml
+++ b/_data/alumni_members.yml
@@ -1,53 +1,80 @@
-- name: Gijsbert Verdoes
-  photo: verdoes.jpg
-  duration: In the Allan Lab 2015 - 2018, now Project manager at the FMD
-  info: Fine mechanical engineer associated with the FMD working in our group
-  email: verdoes@fmd.physics.leidenuniv.nl
-  number_educ: 1
-  education1: Leidse instrumentmakers School
-  education2:
-  education3:
-  education4:
-
-- name: Irene Battisti
-  photo: irene.jpg
-  info: PhD student
-  duration: In the Allan Lab Jan 2015 to June 2019, now R&D scientist at Nearfield Instruments
-  email: Battisti@Physics.LeidenUniv.nl
+- name: Fei Shi
+  photo: fei.jpg
+  # https://qici.weebly.com/fei-shi.html
+  info: Currently associate professor at the <a href="https://cse.sysu.edu.cn/teacher/3434">School of Computer Science and Engineering, Sun Yat-sen University</a>.<br>Former Postdoc, co-advised with Prof. Giulio Chiribella.
+  email: shifei [at] mail [dot] ustc [dot] edu [dot] cn
   number_educ: 3
-  education1: Master Padova University
-  education2: Master thesis at Leiden University with <a href="https://www.physics.leidenuniv.nl/vanruitenbeek">Jan van Ruitenbeek</a>
-  education3: PhD Leiden University!
+  education1: Ph.D., School of Cyber Science and Technology, University of Science and Technology of China
+  education2: Master, School of Mathematical Sciences, University of Science and Technology of China
+  education3: B.S., School of Mathematics and Information Science, Guangzhou University
 
-- name: Doohee Cho
-  photo: Doohee2.jpg
-  info: Postdoc
-  duration: In the Allan Lab May 2017 to June 2019, now assistant professor at Yonsei University
-  email: cho@physics.leidenuniv.nl
-  number_educ: 4
-  education1: B.S. Yonsei University, Korea
-  education2: PhD Yonsei University, Korea with <a href="http://web.yonsei.ac.kr/nano/%ED%95%99%EA%B3%BC%EC%86%8C%EA%B0%9C.htm">In-Whan Lyo</a>
-  education3: Postdoc POSTECH with <a href="http://caldes.ibs.re.kr/html/caldes_en/">Han Woong Yeom</a>
-  education4: Postdoc Rutgers with <a href="http://rcem.rutgers.edu/">Sang-Wook Cheong</a>
-
-- name: Maarten Leeuwenhoek
-  photo: Maarten.png
-  info: PhD Student, shared with the <a href="http://www.groeblacherlab.tudelft.nl">Groeblacher lab</a> at TU Delft under a NanoFront grant.
-  email: M.Leeuwenhoek@tudelft.nl
-  duration: In the Allan Lab December 2015 to February 2020, now design engineer at ASML
-  number_educ: 1
-  education1: Master Leiden University with Milan Allan
-  education2:
-  education3:
-  education4:
-
-- name: Freek Groenewoud
-  photo: Freek.jpg
-  info: Fine mechanical engineer (also associated with the FMD)
-  email: Groenewoud@physics.leidenuniv.nl
+- name: Xingjian Zhang
+  photo: peter.jpg
+  info: Currently Chancellor's Research Fellow, School of Computer Science, Faculty of Engineering and Information Technology, <a href="https://www.uts.edu.au/research/centres/centre-quantum-software-and-information">University of Technology Sydney</a>.<br>Former Postdoc, co-advised with Prof. Giulio Chiribella and Prof. Ravishankar Ramanathan.
+  email: zxj24 [at] hku [dot] hk
   number_educ: 2
-  duration: In the Allan Lab 2018 - 2020
-  education1: Leidse Instrumentmaker School
-  education2: Mechanical Engineer , Hogeschool  Delft
-  education3:
-  education4:
+  education1: Ph.D., Institute for Interdisciplinary Information Sciences (IIIS), Tsinghua University
+  education2: B.S., College of Electronic Information and Optical Engineering, Nankai University
+
+- name: Zhong-Xia Shang
+  photo: zhongxia.jpg
+  info: Currently a <a href="https://ustcszx.github.io/">postdoc</a> at QMATH, University of Copenhagen, Denmark.<br>Former Postdoc, co-advised with Prof. Wang Yao.
+  email: ustcszx [at] mail [dot] ustc [dot] edu [dot] cn
+  number_educ: 2
+  education1: Ph.D., University of Science and Technology of china
+  education2: B.S., School of the Gifted Young, University of Science and Technology of China
+
+# --- Legacy entries from the old Allan Lab template (not displayed) ---
+#- name: Gijsbert Verdoes
+#  photo: verdoes.jpg
+#  duration: In the Allan Lab 2015 - 2018, now Project manager at the FMD
+#  info: Fine mechanical engineer associated with the FMD working in our group
+#  email: verdoes@fmd.physics.leidenuniv.nl
+#  number_educ: 1
+#  education1: Leidse instrumentmakers School
+#  education2:
+#  education3:
+#  education4:
+#
+#- name: Irene Battisti
+#  photo: irene.jpg
+#  info: PhD student
+#  duration: In the Allan Lab Jan 2015 to June 2019, now R&D scientist at Nearfield Instruments
+#  email: Battisti@Physics.LeidenUniv.nl
+#  number_educ: 3
+#  education1: Master Padova University
+#  education2: Master thesis at Leiden University with <a href="https://www.physics.leidenuniv.nl/vanruitenbeek">Jan van Ruitenbeek</a>
+#  education3: PhD Leiden University!
+#
+#- name: Doohee Cho
+#  photo: Doohee2.jpg
+#  info: Postdoc
+#  duration: In the Allan Lab May 2017 to June 2019, now assistant professor at Yonsei University
+#  email: cho@physics.leidenuniv.nl
+#  number_educ: 4
+#  education1: B.S. Yonsei University, Korea
+#  education2: PhD Yonsei University, Korea with <a href="http://web.yonsei.ac.kr/nano/%ED%95%99%EA%B3%BC%EC%86%8C%EA%B0%9C.htm">In-Whan Lyo</a>
+#  education3: Postdoc POSTECH with <a href="http://caldes.ibs.re.kr/html/caldes_en/">Han Woong Yeom</a>
+#  education4: Postdoc Rutgers with <a href="http://rcem.rutgers.edu/">Sang-Wook Cheong</a>
+#
+#- name: Maarten Leeuwenhoek
+#  photo: Maarten.png
+#  info: PhD Student, shared with the <a href="http://www.groeblacherlab.tudelft.nl">Groeblacher lab</a> at TU Delft under a NanoFront grant.
+#  email: M.Leeuwenhoek@tudelft.nl
+#  duration: In the Allan Lab December 2015 to February 2020, now design engineer at ASML
+#  number_educ: 1
+#  education1: Master Leiden University with Milan Allan
+#  education2:
+#  education3:
+#  education4:
+#
+#- name: Freek Groenewoud
+#  photo: Freek.jpg
+#  info: Fine mechanical engineer (also associated with the FMD)
+#  email: Groenewoud@physics.leidenuniv.nl
+#  number_educ: 2
+#  duration: In the Allan Lab 2018 - 2020
+#  education1: Leidse Instrumentmaker School
+#  education2: Mechanical Engineer , Hogeschool  Delft
+#  education3:
+#  education4:

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,3 +1,33 @@
+- date: May, 2026
+  headline: Prof. Qi Zhao has been honoured as “Highly Commended” in the 2025 <a href="https://iopscience.iop.org/journal/2058-9565/page/international-quantum-early-career-award">International Quantum Early Career Award</a>, one of only two researchers worldwide to receive this distinction in 2025, highlighting the international recognition of his research impact in quantum science and technology.
+
+- date: May, 2026
+  headline: Our work “General Framework for Error Interference in Quantum Simulation” in collaboration with Boyang Chen from Tsinghua University and Prof. Xiao Yuan from Peking University, has been published in <a href="https://journals.aps.org/prl/abstract/10.1103/g2n5-qdxh">Physical Review Letters</a>.
+
+- date: May, 2026
+  headline: Our work “Digital adiabatic evolution is universally accurate” in collaboration with Prof. Dong An and Prof. Xiao Yuan from Peking University, and Dr. Dingshun Lv from ByteDance Research, has been published in <a href="https://www.nature.com/articles/s41467-026-73249-z">Nature Communications</a>.
+
+- date: April, 2026
+  headline: Our works “Randomized Truncation for Quantum State Preparation and Series-Truncated Algorithms” and “Trotterization, Operator Scrambling, and Entanglement” have been presented as <a href="https://qctipconf.github.io/">QCTiP 2026</a> contributed talks.
+
+# - date: Feb, 2026
+#   headline: Our former postdoc <a href="https://ustcszx.github.io/">Zhong-Xia Shang</a> joined QMATH, University of Copenhagen, Denmark as a postdoc.
+
+# - date: Mar, 2026
+#   headline: Our former postdoc Xingjian Zhang joined the <a href="https://www.uts.edu.au/research/centres/centre-quantum-software-and-information">University of Technology Sydney</a> as a postdoctoral research fellow.
+
+- date: Feb, 2026
+  headline: Our work “Long-lived remote ion–ion entanglement for scalable quantum repeaters” in collaboration with the team led by Prof. Jian-Wei Pan from the University of Science and Technology of China, has been published in <a href="https://www.nature.com/articles/s41586-026-10177-4">Nature</a>.
+
+- date: Jan, 2026
+  headline: Our work "Fast-forwardable Lindbladians imply quantum phase estimation" [<a href="https://arxiv.org/abs/2510.06759">arXiv:2510.06759</a>] has been presented as a QIP 2026 contributed talk.
+
+- date: Jan, 2026
+  headline: Our former postdoc <a href="https://cse.sysu.edu.cn/teacher/3434">Fei Shi</a> joined the School of Computer Science and Engineering, Sun Yat-sen University as an associate professor.
+
+# - date: Dec, 2025
+#   headline: Our work “Quantum Subspace Verification for Error Correction Codes” in collaboration with Junjie Chen and Prof. Xiongfeng Ma from Tsinghua University, Dr. Pei Zeng from the University of Chicago, and Prof. You Zhou from Fudan University, has been published in <a href="https://journals.aps.org/prxquantum/abstract/10.1103/fyw6-lq1l">PRX Quantum</a>.
+
 - date: Oct, 2025
   headline: Our work “Lindbladian Simulation with Logarithmic Precision Scaling via Two Ancillas” in collaboration with Dr. Xiaogang Li and Prof. Xiao Yuan from Peking University, has been published in <a href="https://journals.aps.org/prl/abstract/10.1103/2cx4-b82c">Physical Review Letters</a>.
 

--- a/_data/postdoc_members.yml
+++ b/_data/postdoc_members.yml
@@ -8,37 +8,11 @@
 #  education3:
 #  education4:
 
-- name: Fei Shi
-  photo: fei.jpg
-  # https://qici.weebly.com/fei-shi.html
-  info: Postdoc, co-advised with Prof. Giulio Chiribella
-  email: shifei [at] mail [dot] ustc [dot] edu [dot] cn
-  number_educ: 3
-  education1: Ph.D., School of Cyber Science and Technology, University of Science and Technology of China
-  education2: Master, School of Mathematical Sciences, University of Science and Technology of China
-  education3: B.S., School of Mathematics and Information Science, Guangzhou University
-
 - name: Tianfeng Feng
   photo: tianfeng.jpg
   info: Postdoc
   email: fengtf [at] hku [dot] hk
   number_educ: 3
   education1: Ph.D., in Quantum Physics, Sun Yat-sen University
-  education2: M.S., in Physical Sciences, Sun Yat-sen University 
+  education2: M.S., in Physical Sciences, Sun Yat-sen University
   education3: B.S., in Physical Science, Guangdong University of Technology
-
-- name: Xingjian Zhang
-  photo: peter.jpg
-  info: Postdoc, co-advised with Prof. Giulio Chiribella and Prof. Ravishankar Ramanathan
-  email: zxj24 [at] hku [dot] hk
-  number_educ: 2
-  education1: Ph.D., Institute for Interdisciplinary Information Sciences (IIIS), Tsinghua University
-  education2: B.S., College of Electronic Information and Optical Engineering, Nankai University
-
-- name: Zhong-Xia Shang
-  photo: zhongxia.jpg
-  info: Postdoc, co-advised with Prof. Wang Yao
-  email: ustcszx [at] mail [dot] ustc [dot] edu [dot] cn
-  number_educ: 2
-  education1: Ph.D., University of Science and Technology of china
-  education2: B.S., School of the Gifted Young, University of Science and Technology of China

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -217,6 +217,64 @@ The following is a subset of our rapidly growing team. We are continuously looki
 
 ---
 
+### Alumni
+{% assign number_printed = 0 %}
+{% for member in site.data.alumni_members %}
+
+{% assign even_odd = number_printed | modulo: 2 %}
+
+{% if even_odd == 0 %}
+<div class="row">
+{% endif %}
+
+<div class="col-sm-6 clearfix">
+  <img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-responsive" width="25%" style="float: left" />
+  <h4>{{ member.name }}</h4>
+  <i>{{ member.info }}</i><!--<br>email: <span class="eml">{{ member.email }}</span>-->
+
+  Email: <span class="eml">{{ member.email }}</span>
+  <ul style="overflow: hidden">
+
+  {% if member.number_educ == 1 %}
+  <li> {{ member.education1 }} </li>
+  {% endif %}
+
+  {% if member.number_educ == 2 %}
+  <li> {{ member.education1 }} </li>
+  <li> {{ member.education2 }} </li>
+  {% endif %}
+
+  {% if member.number_educ == 3 %}
+  <li> {{ member.education1 }} </li>
+  <li> {{ member.education2 }} </li>
+  <li> {{ member.education3 }} </li>
+  {% endif %}
+
+  {% if member.number_educ == 4 %}
+  <li> {{ member.education1 }} </li>
+  <li> {{ member.education2 }} </li>
+  <li> {{ member.education3 }} </li>
+  <li> {{ member.education4 }} </li>
+  {% endif %}
+
+  </ul>
+</div>
+
+{% assign number_printed = number_printed | plus: 1 %}
+
+{% if even_odd == 1 %}
+</div>
+{% endif %}
+
+{% endfor %}
+
+{% assign even_odd = number_printed | modulo: 2 %}
+{% if even_odd == 1 %}
+</div>
+{% endif %}
+
+---
+
 ### Visitors/Interns
 {% assign number_printed = 0 %}
 {% for member in site.data.alumni_visitors %}


### PR DESCRIPTION
- Move Fei Shi, Xingjian Zhang, Zhong-Xia Shang from postdoc to alumni
- Add Alumni section to team page rendering alumni_members
- Add alumni current positions (SYSU, UTS, QMATH Copenhagen)
- Add recent news: PRL/PRX Quantum/Nature publications, QCTiP & QIP talks, IOP award, and alumni placements